### PR TITLE
[deploy] use Trusted Publisher instead of API token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,4 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# This workflow will upload a Python Package when a release is created
 
 name: Upload Python Package
 
@@ -18,6 +12,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/android-sms-gateway
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -41,6 +40,3 @@ jobs:
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for package publishing
	- Simplified workflow configuration
	- Enhanced security settings for package deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->