### PR TITLE
[enums] add batch webhooks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This client abstracts away the complexities of the underlying HTTP API while pro
     - [Client Configuration](#client-configuration)
     - [Available Methods](#available-methods)
       - [Message Methods](#message-methods)
+      - [Inbox methods](#inbox-methods)
       - [Webhook Methods](#webhook-methods)
       - [Device Methods](#device-methods)
       - [Settings Methods](#settings-methods)
@@ -53,6 +54,7 @@ This client abstracts away the complexities of the underlying HTTP API while pro
       - [Message](#message)
       - [MessageState](#messagestate)
       - [Webhook](#webhook)
+      - [InboxRefreshRequest](#inboxrefreshrequest)
       - [Device](#device)
       - [DeviceSettings](#devicesettings)
       - [TokenRequest](#tokenrequest)
@@ -93,7 +95,7 @@ This client abstracts away the complexities of the underlying HTTP API while pro
 - 📝 **Logging**: Retrieve system logs with time range filtering
 - 🏥 **Health Checks**: Liveness, readiness, and startup probes
 - 📱 **Device Management**: List and remove registered devices
-- 📥 **Inbox Export**: Export received messages via webhooks
+- 📥 **Inbox Refresh**: Refresh device inboxes with webhook delivery (individual or batch)
 
 ## ⚙️ Requirements
 
@@ -305,12 +307,19 @@ Both clients (`APIClient` and `AsyncAPIClient`) support these parameters:
 
 #### Message Methods
 
-| Method                                                                  | Description                        | Return Type                 |
-| ----------------------------------------------------------------------- | ---------------------------------- | --------------------------- |
-| `send(message, *, skip_phone_validation=False, device_active_within=0)` | Send SMS message                   | `domain.MessageState`       |
-| `get_state(id)`                                                         | Get message state by ID            | `domain.MessageState`       |
-| `get_messages(*, filter=None, pagination=None)`                         | List messages with filtering       | `List[domain.MessageState]` |
-| `export_inbox(request)`                                                 | Export inbox messages via webhooks | `dict`                      |
+| Method                                                                  | Description                  | Return Type                 |
+| ----------------------------------------------------------------------- | ---------------------------- | --------------------------- |
+| `send(message, *, skip_phone_validation=False, device_active_within=0)` | Send SMS message             | `domain.MessageState`       |
+| `get_state(id)`                                                         | Get message state by ID      | `domain.MessageState`       |
+| `get_messages(*, query=None, pagination=None)`                          | List messages with filtering | `List[domain.MessageState]` |
+
+#### Inbox methods
+
+| Method                                                       | Description            | Return Type             |
+| ------------------------------------------------------------ | ---------------------- | ----------------------- |
+| `list_inbox_messages(*, inbox_filter=None, pagination=None)` | List inbox messages    | `List[IncomingMessage]` |
+| `refresh_inbox(request)`                                     | Refresh inbox messages | `dict`                  |
+| `download_attachment(message_id, part_id)`                   | Download attachment    | `bytes`                 |
 
 #### Webhook Methods
 
@@ -400,6 +409,17 @@ class Webhook:
     device_id: Optional[str] = None # Associated device ID
 ```
 
+#### InboxRefreshRequest
+
+```python
+class InboxRefreshRequest:
+    since: datetime                              # Start of time range (required)
+    until: datetime                              # End of time range (required)
+    device_id: Optional[str] = None              # Device ID to refresh messages for
+    message_types: Optional[List[str]] = None    # SMS, DATA_SMS, MMS, MMS_DOWNLOADED
+    webhook_delivery: Optional[WebhookDelivery] = None  # Delivery mode
+```
+
 #### Device
 
 ```python
@@ -484,6 +504,15 @@ class WebhookEvent(enum.Enum):
     SYSTEM_PING = "system:ping"
     MMS_RECEIVED = "mms:received"
     MMS_DOWNLOADED = "mms:downloaded"
+    SMS_BATCH_RECEIVED = "sms:batch:received"
+    SMS_DATA_BATCH_RECEIVED = "sms:batch:data-received"
+    MMS_BATCH_RECEIVED = "mms:batch:received"
+    MMS_BATCH_DOWNLOADED = "mms:batch:downloaded"
+
+class WebhookDelivery(enum.Enum):
+    DISABLED = "Disabled"
+    INDIVIDUAL = "Individual"
+    BATCH = "Batch"
 
 class MessagePriority(enum.IntEnum):
     MINIMUM = -128

--- a/android_sms_gateway/__init__.py
+++ b/android_sms_gateway/__init__.py
@@ -10,14 +10,12 @@ from .domain import (
     IncomingMessage,
     IncomingMessageAttachment,
     InboxQueryFilter,
+    InboxRefreshRequest,
     LogEntry,
     Message,
     MessagesExportRequest,
     MessagesQueryFilter,
     MessageState,
-    MmsDownloadedAttachment,
-    MmsDownloadedPayload,
-    MmsReceivedPayload,
     QueryPagination,
     RecipientState,
     SettingsEncryption,
@@ -31,6 +29,17 @@ from .domain import (
     TokenResponse,
     Webhook,
 )
+from .webhooks import (
+    MmsBatchDownloadedPayload,
+    MmsBatchReceivedPayload,
+    MmsDownloadedAttachment,
+    MmsDownloadedPayload,
+    MmsReceivedPayload,
+    SmsBatchDataReceivedPayload,
+    SmsBatchReceivedPayload,
+    SmsDataReceivedPayload,
+    SmsReceivedPayload,
+)
 from .encryption import Encryptor
 from .enums import (
     HealthStatus,
@@ -40,6 +49,7 @@ from .enums import (
     MessagesProcessingOrder,
     ProcessState,
     SimSelectionMode,
+    WebhookDelivery,
     WebhookEvent,
 )
 from .http import HttpClient
@@ -59,6 +69,7 @@ __all__ = (
     "IncomingMessage",
     "IncomingMessageAttachment",
     "InboxQueryFilter",
+    "InboxRefreshRequest",
     "LimitPeriod",
     "LogEntry",
     "LogEntryPriority",
@@ -68,6 +79,8 @@ __all__ = (
     "MessagesProcessingOrder",
     "MessagesQueryFilter",
     "MessageState",
+    "MmsBatchDownloadedPayload",
+    "MmsBatchReceivedPayload",
     "MmsDownloadedAttachment",
     "MmsDownloadedPayload",
     "MmsReceivedPayload",
@@ -81,10 +94,15 @@ __all__ = (
     "SettingsPing",
     "SettingsWebhooks",
     "SimSelectionMode",
+    "SmsBatchDataReceivedPayload",
+    "SmsBatchReceivedPayload",
+    "SmsDataReceivedPayload",
+    "SmsReceivedPayload",
     "TextMessage",
     "TokenRequest",
     "TokenResponse",
     "Webhook",
+    "WebhookDelivery",
     "WebhookEvent",
 )
 

--- a/android_sms_gateway/_utils.py
+++ b/android_sms_gateway/_utils.py
@@ -1,0 +1,16 @@
+import datetime
+import typing as t
+
+
+def _parse_iso(value: t.Optional[str]) -> t.Optional[datetime.datetime]:
+    """Parse an ISO 8601 timestamp string to a datetime object.
+
+    Args:
+        value: An ISO 8601 timestamp string (e.g., "2024-01-01T12:00:00Z") or None.
+
+    Returns:
+        A datetime object or None if value is None.
+    """
+    if value is None:
+        return None
+    return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/android_sms_gateway/client.py
+++ b/android_sms_gateway/client.py
@@ -236,6 +236,8 @@ class APIClient(BaseClient):
 
     def export_inbox(self, request: domain.MessagesExportRequest) -> t.Dict[str, t.Any]:
         """
+        Deprecated: use refresh_inbox instead.
+
         Initiates process of inbox messages export via webhooks.
 
         Args:
@@ -249,6 +251,25 @@ class APIClient(BaseClient):
 
         return self.http.post(
             f"{self.base_url}/messages/inbox/export",
+            payload=request.asdict(),
+            headers=self.headers,
+        )
+
+    def refresh_inbox(self, request: domain.InboxRefreshRequest) -> t.Dict[str, t.Any]:
+        """
+        Initiates process of inbox messages refresh.
+
+        Args:
+            request: The refresh request containing device ID and time range.
+
+        Returns:
+            A dictionary containing the response.
+        """
+        if self.http is None:
+            raise ValueError("HTTP client not initialized")
+
+        return self.http.post(
+            f"{self.base_url}/inbox/refresh",
             payload=request.asdict(),
             headers=self.headers,
         )
@@ -661,9 +682,7 @@ class AsyncAPIClient(BaseClient):
         if self.http is None:
             raise ValueError("HTTP client not initialized")
 
-        await self.http.delete(
-            f"{self.base_url}/messages/{_id}", headers=self.headers
-        )
+        await self.http.delete(f"{self.base_url}/messages/{_id}", headers=self.headers)
 
     async def get_state(self, _id: str) -> domain.MessageState:
         """
@@ -727,6 +746,8 @@ class AsyncAPIClient(BaseClient):
         self, request: domain.MessagesExportRequest
     ) -> t.Dict[str, t.Any]:
         """
+        Deprecated: use refresh_inbox instead.
+
         Initiates process of inbox messages export via webhooks.
 
         Args:
@@ -740,6 +761,27 @@ class AsyncAPIClient(BaseClient):
 
         return await self.http.post(
             f"{self.base_url}/messages/inbox/export",
+            payload=request.asdict(),
+            headers=self.headers,
+        )
+
+    async def refresh_inbox(
+        self, request: domain.InboxRefreshRequest
+    ) -> t.Dict[str, t.Any]:
+        """
+        Initiates process of inbox messages refresh.
+
+        Args:
+            request: The refresh request containing device ID and time range.
+
+        Returns:
+            A dictionary containing the response.
+        """
+        if self.http is None:
+            raise ValueError("HTTP client not initialized")
+
+        return await self.http.post(
+            f"{self.base_url}/inbox/refresh",
             payload=request.asdict(),
             headers=self.headers,
         )

--- a/android_sms_gateway/domain.py
+++ b/android_sms_gateway/domain.py
@@ -4,9 +4,11 @@ import datetime
 import enum
 import typing as t
 
+from ._utils import _parse_iso
 from .enums import (
     ProcessState,
     WebhookEvent,
+    WebhookDelivery,
     MessagePriority,
     LimitPeriod,
     SimSelectionMode,
@@ -14,20 +16,11 @@ from .enums import (
     HealthStatus,
     LogEntryPriority,
 )
-
-
-def _parse_iso(value: t.Optional[str]) -> t.Optional[datetime.datetime]:
-    """Parse an ISO 8601 timestamp string to a datetime object.
-
-    Args:
-        value: An ISO 8601 timestamp string (e.g., "2024-01-01T12:00:00Z") or None.
-
-    Returns:
-        A datetime object or None if value is None.
-    """
-    if value is None:
-        return None
-    return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+from .webhooks import (  # noqa: F401  re-exported for backward compatibility
+    MmsDownloadedAttachment,
+    MmsDownloadedPayload,
+    MmsReceivedPayload,
+)
 
 
 def snake_to_camel(snake_str):
@@ -911,8 +904,7 @@ class IncomingMessage:
         attachments = None
         if "attachments" in payload and payload["attachments"] is not None:
             attachments = [
-                IncomingMessageAttachment.from_dict(a)
-                for a in payload["attachments"]
+                IncomingMessageAttachment.from_dict(a) for a in payload["attachments"]
             ]
 
         return cls(
@@ -958,115 +950,38 @@ class InboxQueryFilter:
         return params
 
 
-# MMS webhook payload types
+# Inbox refresh request
 
 
 @dataclasses.dataclass(frozen=True)
-class MmsReceivedPayload:
-    """Payload of an mms:received event (MMS notification, not yet downloaded)."""
+class InboxRefreshRequest:
+    """Represents a request to refresh messages from the device inbox."""
 
-    message_id: str
-    """The unique identifier of the message."""
-    phone_number: str
-    """The phone number of the sender."""
-    sender: str
-    """The phone number of the message sender."""
-    transaction_id: str
-    """Unique MMS transaction identifier."""
-    content_class: str
-    """MMS content classification."""
-    size: int
-    """Attachment size in bytes."""
-    received_at: datetime.datetime
-    """The timestamp when the MMS message was received."""
-    recipient: t.Optional[str] = None
-    """The phone number of the message recipient."""
-    sim_number: t.Optional[int] = None
-    """The SIM card number that received the message."""
-    subject: t.Optional[str] = None
-    """Message subject line."""
+    since: datetime.datetime
+    """The start of the time range to refresh."""
+    until: datetime.datetime
+    """The end of the time range to refresh."""
+    device_id: t.Optional[str] = None
+    """The ID of the device to refresh messages for."""
+    message_types: t.Optional[t.List[str]] = None
+    """List of message types to refresh (SMS, DATA_SMS, MMS, MMS_DOWNLOADED)."""
+    webhook_delivery: t.Optional[WebhookDelivery] = None
+    """Delivery mode for webhooks."""
 
-    @classmethod
-    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsReceivedPayload":
-        """Creates an MmsReceivedPayload instance from a dictionary."""
-        return cls(
-            message_id=payload["messageId"],
-            phone_number=payload["phoneNumber"],
-            sender=payload["sender"],
-            transaction_id=payload["transactionId"],
-            content_class=payload["contentClass"],
-            size=payload["size"],
-            received_at=_parse_iso(payload["receivedAt"]),
-            recipient=payload.get("recipient"),
-            sim_number=payload.get("simNumber"),
-            subject=payload.get("subject"),
-        )
+    def asdict(self) -> t.Dict[str, t.Any]:
+        """Returns a dictionary representation of the request.
 
-
-@dataclasses.dataclass(frozen=True)
-class MmsDownloadedAttachment:
-    """Metadata for a non-text MMS part (attachment)."""
-
-    part_id: int
-    """The _id from content://mms/part."""
-    content_type: str
-    """MIME type of the attachment (e.g. image/jpeg)."""
-    name: t.Optional[str] = None
-    """Filename of the attachment, if present."""
-    data: t.Optional[str] = None
-    """Base64-encoded attachment data, if available."""
-    size: t.Optional[int] = None
-    """Size in bytes, if known."""
-
-    @classmethod
-    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsDownloadedAttachment":
-        """Creates an MmsDownloadedAttachment instance from a dictionary."""
-        return cls(
-            part_id=payload["partId"],
-            content_type=payload["contentType"],
-            name=payload.get("name"),
-            data=payload.get("data"),
-            size=payload.get("size"),
-        )
-
-
-@dataclasses.dataclass(frozen=True)
-class MmsDownloadedPayload:
-    """Payload of an mms:downloaded event (fully downloaded MMS with attachments)."""
-
-    message_id: str
-    """The unique identifier of the message."""
-    phone_number: str
-    """The phone number of the sender."""
-    sender: str
-    """The phone number of the message sender."""
-    attachments: t.List[MmsDownloadedAttachment]
-    """Metadata for non-text MMS parts, including optional Base64 content."""
-    received_at: datetime.datetime
-    """The timestamp when the MMS message was received."""
-    recipient: t.Optional[str] = None
-    """The phone number of the message recipient."""
-    sim_number: t.Optional[int] = None
-    """The SIM card number that received the message."""
-    subject: t.Optional[str] = None
-    """Message subject line."""
-    body: t.Optional[str] = None
-    """Aggregated text content of the MMS message."""
-
-    @classmethod
-    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsDownloadedPayload":
-        """Creates an MmsDownloadedPayload instance from a dictionary."""
-        return cls(
-            message_id=payload["messageId"],
-            phone_number=payload["phoneNumber"],
-            sender=payload["sender"],
-            attachments=[
-                MmsDownloadedAttachment.from_dict(a)
-                for a in payload.get("attachments", [])
-            ],
-            received_at=_parse_iso(payload["receivedAt"]),
-            recipient=payload.get("recipient"),
-            sim_number=payload.get("simNumber"),
-            subject=payload.get("subject"),
-            body=payload.get("body"),
-        )
+        Returns:
+            A dictionary containing the request data.
+        """
+        result: t.Dict[str, t.Any] = {
+            "since": self.since.isoformat(),
+            "until": self.until.isoformat(),
+        }
+        if self.device_id is not None:
+            result["deviceId"] = self.device_id
+        if self.message_types is not None:
+            result["messageTypes"] = self.message_types
+        if self.webhook_delivery is not None:
+            result["webhookDelivery"] = self.webhook_delivery.value
+        return result

--- a/android_sms_gateway/enums.py
+++ b/android_sms_gateway/enums.py
@@ -46,6 +46,31 @@ class WebhookEvent(enum.Enum):
     APP_STARTED = "app:started"
     """Triggered when the application is started."""
 
+    SMS_BATCH_RECEIVED = "sms:batch:received"
+    """Triggered when a batch of SMS messages is received."""
+
+    SMS_DATA_BATCH_RECEIVED = "sms:batch:data-received"
+    """Triggered when a batch of data SMS messages is received."""
+
+    MMS_BATCH_RECEIVED = "mms:batch:received"
+    """Triggered when a batch of MMS messages is received."""
+
+    MMS_BATCH_DOWNLOADED = "mms:batch:downloaded"
+    """Triggered when a batch of MMS messages is downloaded."""
+
+
+class WebhookDelivery(enum.Enum):
+    """Delivery mode for webhooks."""
+
+    DISABLED = "Disabled"
+    """Disable webhook delivery."""
+
+    INDIVIDUAL = "Individual"
+    """Deliver webhooks individually (one per message)."""
+
+    BATCH = "Batch"
+    """Deliver webhooks as ordered batches."""
+
 
 class MessagePriority(enum.IntEnum):
     """Priority levels for messages."""

--- a/android_sms_gateway/webhooks.py
+++ b/android_sms_gateway/webhooks.py
@@ -1,0 +1,259 @@
+import dataclasses
+import datetime
+import typing as t
+
+from ._utils import _parse_iso
+
+# MMS webhook payload types
+
+
+@dataclasses.dataclass(frozen=True)
+class MmsReceivedPayload:
+    """Payload of an mms:received event (MMS notification, not yet downloaded)."""
+
+    message_id: str
+    """The unique identifier of the message."""
+    phone_number: str
+    """The phone number of the sender."""
+    sender: str
+    """The phone number of the message sender."""
+    transaction_id: str
+    """Unique MMS transaction identifier."""
+    content_class: str
+    """MMS content classification."""
+    size: int
+    """Attachment size in bytes."""
+    received_at: datetime.datetime
+    """The timestamp when the MMS message was received."""
+    recipient: t.Optional[str] = None
+    """The phone number of the message recipient."""
+    sim_number: t.Optional[int] = None
+    """The SIM card number that received the message."""
+    subject: t.Optional[str] = None
+    """Message subject line."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsReceivedPayload":
+        """Creates an MmsReceivedPayload instance from a dictionary."""
+        return cls(
+            message_id=payload["messageId"],
+            phone_number=payload["phoneNumber"],
+            sender=payload["sender"],
+            transaction_id=payload["transactionId"],
+            content_class=payload["contentClass"],
+            size=payload["size"],
+            received_at=_parse_iso(payload["receivedAt"]),
+            recipient=payload.get("recipient"),
+            sim_number=payload.get("simNumber"),
+            subject=payload.get("subject"),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class MmsDownloadedAttachment:
+    """Metadata for a non-text MMS part (attachment)."""
+
+    part_id: int
+    """The _id from content://mms/part."""
+    content_type: str
+    """MIME type of the attachment (e.g. image/jpeg)."""
+    name: t.Optional[str] = None
+    """Filename of the attachment, if present."""
+    data: t.Optional[str] = None
+    """Base64-encoded attachment data, if available."""
+    size: t.Optional[int] = None
+    """Size in bytes, if known."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsDownloadedAttachment":
+        """Creates an MmsDownloadedAttachment instance from a dictionary."""
+        return cls(
+            part_id=payload["partId"],
+            content_type=payload["contentType"],
+            name=payload.get("name"),
+            data=payload.get("data"),
+            size=payload.get("size"),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class MmsDownloadedPayload:
+    """Payload of an mms:downloaded event (fully downloaded MMS with attachments)."""
+
+    message_id: str
+    """The unique identifier of the message."""
+    phone_number: str
+    """The phone number of the sender."""
+    sender: str
+    """The phone number of the message sender."""
+    attachments: t.List[MmsDownloadedAttachment]
+    """Metadata for non-text MMS parts, including optional Base64 content."""
+    received_at: datetime.datetime
+    """The timestamp when the MMS message was received."""
+    recipient: t.Optional[str] = None
+    """The phone number of the message recipient."""
+    sim_number: t.Optional[int] = None
+    """The SIM card number that received the message."""
+    subject: t.Optional[str] = None
+    """Message subject line."""
+    body: t.Optional[str] = None
+    """Aggregated text content of the MMS message."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsDownloadedPayload":
+        """Creates an MmsDownloadedPayload instance from a dictionary."""
+        return cls(
+            message_id=payload["messageId"],
+            phone_number=payload["phoneNumber"],
+            sender=payload["sender"],
+            attachments=[
+                MmsDownloadedAttachment.from_dict(a)
+                for a in payload.get("attachments", [])
+            ],
+            received_at=_parse_iso(payload["receivedAt"]),
+            recipient=payload.get("recipient"),
+            sim_number=payload.get("simNumber"),
+            subject=payload.get("subject"),
+            body=payload.get("body"),
+        )
+
+
+# SMS webhook payload types
+
+
+@dataclasses.dataclass(frozen=True)
+class SmsReceivedPayload:
+    """Payload of an sms:received event."""
+
+    message_id: str
+    """The unique identifier of the message."""
+    phone_number: str
+    """The phone number of the sender."""
+    sender: str
+    """The phone number of the message sender."""
+    message: str
+    """The content of the SMS message received."""
+    received_at: datetime.datetime
+    """The timestamp when the SMS message was received."""
+    recipient: t.Optional[str] = None
+    """The phone number of the message recipient."""
+    sim_number: t.Optional[int] = None
+    """The SIM card number that received the message."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "SmsReceivedPayload":
+        """Creates an SmsReceivedPayload instance from a dictionary."""
+        return cls(
+            message_id=payload["messageId"],
+            phone_number=payload["phoneNumber"],
+            sender=payload["sender"],
+            message=payload["message"],
+            received_at=_parse_iso(payload["receivedAt"]),
+            recipient=payload.get("recipient"),
+            sim_number=payload.get("simNumber"),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class SmsDataReceivedPayload:
+    """Payload of an sms:data-received event."""
+
+    message_id: str
+    """The unique identifier of the message."""
+    phone_number: str
+    """The phone number of the sender."""
+    sender: str
+    """The phone number of the message sender."""
+    data: str
+    """Base64-encoded content of the SMS message received."""
+    received_at: datetime.datetime
+    """The timestamp when the SMS message was received."""
+    recipient: t.Optional[str] = None
+    """The phone number of the message recipient."""
+    sim_number: t.Optional[int] = None
+    """The SIM card number that received the message."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "SmsDataReceivedPayload":
+        """Creates an SmsDataReceivedPayload instance from a dictionary."""
+        return cls(
+            message_id=payload["messageId"],
+            phone_number=payload["phoneNumber"],
+            sender=payload["sender"],
+            data=payload["data"],
+            received_at=_parse_iso(payload["receivedAt"]),
+            recipient=payload.get("recipient"),
+            sim_number=payload.get("simNumber"),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class SmsBatchReceivedPayload:
+    """Payload of an sms:batch:received event."""
+
+    messages: t.Tuple[SmsReceivedPayload, ...]
+    """The ordered tuple of received SMS messages."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "SmsBatchReceivedPayload":
+        """Creates an SmsBatchReceivedPayload instance from a dictionary."""
+        messages = payload.get("messages")
+        if not isinstance(messages, (list, tuple)):
+            messages = ()
+        return cls(
+            messages=tuple(SmsReceivedPayload.from_dict(m) for m in messages)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class SmsBatchDataReceivedPayload:
+    """Payload of an sms:batch:data-received event."""
+
+    messages: t.Tuple[SmsDataReceivedPayload, ...]
+    """The ordered tuple of received data SMS messages."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "SmsBatchDataReceivedPayload":
+        """Creates an SmsBatchDataReceivedPayload instance from a dictionary."""
+        messages = payload.get("messages")
+        if not isinstance(messages, (list, tuple)):
+            messages = ()
+        return cls(
+            messages=tuple(SmsDataReceivedPayload.from_dict(m) for m in messages)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class MmsBatchReceivedPayload:
+    """Payload of an mms:batch:received event."""
+
+    messages: t.Tuple[MmsReceivedPayload, ...]
+    """The ordered tuple of received MMS messages."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsBatchReceivedPayload":
+        """Creates an MmsBatchReceivedPayload instance from a dictionary."""
+        messages = payload.get("messages")
+        if not isinstance(messages, (list, tuple)):
+            messages = ()
+        return cls(
+            messages=tuple(MmsReceivedPayload.from_dict(m) for m in messages)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class MmsBatchDownloadedPayload:
+    """Payload of an mms:batch:downloaded event."""
+
+    messages: t.Tuple[MmsDownloadedPayload, ...]
+    """The ordered tuple of downloaded MMS messages."""
+
+    @classmethod
+    def from_dict(cls, payload: t.Dict[str, t.Any]) -> "MmsBatchDownloadedPayload":
+        """Creates an MmsBatchDownloadedPayload instance from a dictionary."""
+        messages = payload.get("messages")
+        if not isinstance(messages, (list, tuple)):
+            messages = ()
+        return cls(
+            messages=tuple(MmsDownloadedPayload.from_dict(m) for m in messages)
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,16 @@
+import asyncio
+import datetime
 import os
 import pytest
 
-from android_sms_gateway.client import APIClient
+from android_sms_gateway.client import APIClient, AsyncAPIClient
 from android_sms_gateway.constants import DEFAULT_URL
-from android_sms_gateway.domain import Webhook
-from android_sms_gateway.enums import WebhookEvent
+from android_sms_gateway.domain import (
+    Webhook,
+    InboxRefreshRequest,
+    MessagesExportRequest,
+)
+from android_sms_gateway.enums import WebhookDelivery, WebhookEvent
 from android_sms_gateway.http import RequestsHttpClient
 from android_sms_gateway import errors
 
@@ -116,3 +122,223 @@ class TestAPIClient:
         webhooks = client.get_webhooks()
 
         assert not any([webhook.id == "webhook_123" for webhook in webhooks])
+
+
+class StubHttpClient:
+    """
+    A minimal HttpClient protocol stub that records post calls and returns a
+    canned response, allowing client tests to run without a live server or
+    API credentials.
+    """
+
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def post(self, url, payload, *, headers=None):
+        self.calls.append(
+            {"url": url, "payload": payload, "headers": headers}
+        )
+        return self.response
+
+
+class StubAsyncHttpClient:
+    """
+    A minimal AsyncHttpClient protocol stub that records post calls and
+    returns a canned response, allowing async client tests to run without a
+    live server or API credentials.
+    """
+
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    async def post(self, url, payload, *, headers=None):
+        self.calls.append(
+            {"url": url, "payload": payload, "headers": headers}
+        )
+        return self.response
+
+
+def _refresh_request():
+    return InboxRefreshRequest(
+        since=datetime.datetime(2026, 8, 1, 10, 0, 0),
+        until=datetime.datetime(2026, 8, 2, 10, 0, 0),
+        device_id="device_1",
+        webhook_delivery=WebhookDelivery.INDIVIDUAL,
+    )
+
+
+def _export_request():
+    return MessagesExportRequest(
+        device_id="device_1",
+        since=datetime.datetime(2026, 8, 1, 10, 0, 0),
+        until=datetime.datetime(2026, 8, 2, 10, 0, 0),
+    )
+
+
+def test_refresh_inbox_posts_request_to_inbox_refresh():
+    """
+    Tests that refresh_inbox POSTs the request payload to /inbox/refresh
+    and returns the response body.
+    """
+    stub = StubHttpClient({"status": "ok"})
+    client = APIClient(
+        "user", "pass", base_url="https://example.com", http=stub
+    )
+    request = _refresh_request()
+
+    result = client.refresh_inbox(request)
+
+    assert result == {"status": "ok"}
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["url"] == "https://example.com/inbox/refresh"
+    assert stub.calls[0]["payload"] == request.asdict()
+    assert stub.calls[0]["headers"]["Authorization"]
+
+
+def test_async_refresh_inbox_posts_request_to_inbox_refresh():
+    """
+    Tests that the async refresh_inbox POSTs the request payload to
+    /inbox/refresh and returns the response body.
+    """
+    stub = StubAsyncHttpClient({"status": "ok"})
+    client = AsyncAPIClient(
+        "user", "pass", base_url="https://example.com", http_client=stub
+    )
+    request = _refresh_request()
+
+    result = asyncio.run(client.refresh_inbox(request))
+
+    assert result == {"status": "ok"}
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["url"] == "https://example.com/inbox/refresh"
+    assert stub.calls[0]["payload"] == request.asdict()
+
+
+class RaisingStubHttpClient(StubHttpClient):
+    """
+    A StubHttpClient variant whose post raises the configured error,
+    mirroring an HTTP client surfacing a non-202 error status.
+    """
+
+    def post(self, url, payload, *, headers=None):
+        super().post(url, payload, headers=headers)
+        raise self.response
+
+
+class RaisingStubAsyncHttpClient(StubAsyncHttpClient):
+    """
+    A StubAsyncHttpClient variant whose post raises the configured error,
+    mirroring an HTTP client surfacing a non-202 error status.
+    """
+
+    async def post(self, url, payload, *, headers=None):
+        self.calls.append(
+            {"url": url, "payload": payload, "headers": headers}
+        )
+        raise self.response
+
+
+def test_refresh_inbox_handles_202_empty_body():
+    """
+    Tests that refresh_inbox returns the empty dict produced by the HTTP
+    layer for a 202 Accepted response with an empty body, without decoding
+    errors.
+    """
+    stub = StubHttpClient({})
+    client = APIClient(
+        "user", "pass", base_url="https://example.com", http=stub
+    )
+
+    result = client.refresh_inbox(_refresh_request())
+
+    assert result == {}
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["url"] == "https://example.com/inbox/refresh"
+
+
+def test_async_refresh_inbox_handles_202_empty_body():
+    """
+    Tests that the async refresh_inbox returns the empty dict produced by
+    the HTTP layer for a 202 Accepted response with an empty body, without
+    decoding errors.
+    """
+    stub = StubAsyncHttpClient({})
+    client = AsyncAPIClient(
+        "user", "pass", base_url="https://example.com", http_client=stub
+    )
+
+    result = asyncio.run(client.refresh_inbox(_refresh_request()))
+
+    assert result == {}
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["url"] == "https://example.com/inbox/refresh"
+
+
+def test_refresh_inbox_propagates_non_202_error_status():
+    """
+    Tests that refresh_inbox propagates the API error raised by the HTTP
+    layer for a non-202 error status instead of swallowing it.
+    """
+    stub = RaisingStubHttpClient(errors.InternalServerError("boom", status_code=500))
+    client = APIClient(
+        "user", "pass", base_url="https://example.com", http=stub
+    )
+
+    with pytest.raises(errors.InternalServerError):
+        client.refresh_inbox(_refresh_request())
+
+
+def test_async_refresh_inbox_propagates_non_202_error_status():
+    """
+    Tests that the async refresh_inbox propagates the API error raised by
+    the HTTP layer for a non-202 error status instead of swallowing it.
+    """
+    stub = RaisingStubAsyncHttpClient(errors.InternalServerError("boom", status_code=500))
+    client = AsyncAPIClient(
+        "user", "pass", base_url="https://example.com", http_client=stub
+    )
+
+    with pytest.raises(errors.InternalServerError):
+        asyncio.run(client.refresh_inbox(_refresh_request()))
+
+
+def test_export_inbox_posts_request_to_messages_inbox_export():
+    """
+    Regression lock: export_inbox must POST to the deprecated server alias
+    /messages/inbox/export (not /inbox/export) and return the response body.
+    """
+    stub = StubHttpClient({"status": "ok"})
+    client = APIClient(
+        "user", "pass", base_url="https://example.com", http=stub
+    )
+    request = _export_request()
+
+    result = client.export_inbox(request)
+
+    assert result == {"status": "ok"}
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["url"] == "https://example.com/messages/inbox/export"
+    assert stub.calls[0]["url"] != "https://example.com/inbox/export"
+    assert stub.calls[0]["payload"] == request.asdict()
+
+
+def test_async_export_inbox_posts_request_to_messages_inbox_export():
+    """
+    Regression lock: async export_inbox must POST to the deprecated server
+    alias /messages/inbox/export (not /inbox/export) and return the response
+    body.
+    """
+    stub = StubAsyncHttpClient({"status": "ok"})
+    client = AsyncAPIClient(
+        "user", "pass", base_url="https://example.com", http_client=stub
+    )
+    request = _export_request()
+
+    result = asyncio.run(client.export_inbox(request))
+
+    assert result == {"status": "ok"}
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["url"] == "https://example.com/messages/inbox/export"
+    assert stub.calls[0]["payload"] == request.asdict()

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,7 +1,7 @@
 import pytest
 import datetime
 
-from android_sms_gateway.enums import WebhookEvent, MessagePriority
+from android_sms_gateway.enums import WebhookEvent, MessagePriority, WebhookDelivery
 from android_sms_gateway.domain import (
     MessageState,
     RecipientState,
@@ -9,6 +9,7 @@ from android_sms_gateway.domain import (
     Message,
     TextMessage,
     DataMessage,
+    InboxRefreshRequest,
 )
 
 
@@ -483,3 +484,96 @@ def test_message_serialization_format_for_data_message():
     }
 
     assert message.asdict() == expected_dict
+
+
+# Inbox refresh request
+
+
+def test_inbox_refresh_request_asdict_includes_device_id():
+    """
+    Tests that InboxRefreshRequest.asdict includes deviceId when device_id
+    is set, along with ISO-8601 since/until values.
+    """
+    since = datetime.datetime(2026, 8, 1, 10, 0, 0)
+    until = datetime.datetime(2026, 8, 2, 10, 0, 0)
+    request = InboxRefreshRequest(
+        since=since,
+        until=until,
+        device_id="device_1",
+    )
+
+    result = request.asdict()
+
+    assert result["deviceId"] == "device_1"
+    assert result["since"] == "2026-08-01T10:00:00"
+    assert result["until"] == "2026-08-02T10:00:00"
+
+
+def test_inbox_refresh_request_asdict_omits_device_id_when_none():
+    """
+    Tests that InboxRefreshRequest.asdict omits deviceId when device_id
+    is None.
+    """
+    request = InboxRefreshRequest(
+        since=datetime.datetime(2026, 8, 1),
+        until=datetime.datetime(2026, 8, 2),
+        device_id=None,
+    )
+
+    assert "deviceId" not in request.asdict()
+
+
+def test_inbox_refresh_request_asdict_since_until_iso_8601():
+    """
+    Tests that since/until serialize to ISO-8601 strings in
+    InboxRefreshRequest.asdict.
+    """
+    since = datetime.datetime(2026, 8, 1, 10, 30, 15)
+    until = since + datetime.timedelta(hours=2)
+
+    result = InboxRefreshRequest(since=since, until=until).asdict()
+
+    assert result["since"] == since.isoformat()
+    assert result["until"] == until.isoformat()
+    assert isinstance(result["since"], str)
+    assert isinstance(result["until"], str)
+
+
+def test_inbox_refresh_request_asdict_optional_fields():
+    """
+    Tests that InboxRefreshRequest.asdict includes messageTypes,
+    triggerWebhooks and webhookDelivery when set, and omits them when None.
+    """
+    since = datetime.datetime(2026, 8, 1)
+    until = datetime.datetime(2026, 8, 2)
+
+    full = InboxRefreshRequest(
+        since=since,
+        until=until,
+        message_types=["SMS", "DATA_SMS", "MMS", "MMS_DOWNLOADED"],
+        webhook_delivery=WebhookDelivery.BATCH,
+    )
+    result = full.asdict()
+    assert result["messageTypes"] == ["SMS", "DATA_SMS", "MMS", "MMS_DOWNLOADED"]
+    assert result["webhookDelivery"] == "Batch"
+
+    minimal = InboxRefreshRequest(since=since, until=until)
+    result = minimal.asdict()
+    assert "messageTypes" not in result
+    assert "webhookDelivery" not in result
+
+
+def test_mms_payload_types_importable_from_domain():
+    """
+    Regression test: MMS webhook payload types must remain importable from
+    android_sms_gateway.domain (defined in .webhooks but re-exported for
+    backward compatibility with master).
+    """
+    import android_sms_gateway
+    import android_sms_gateway.domain as domain
+    from android_sms_gateway import webhooks
+
+    for name in ("MmsReceivedPayload", "MmsDownloadedPayload", "MmsDownloadedAttachment"):
+        assert hasattr(domain, name), f"android_sms_gateway.domain.{name} is missing"
+        assert hasattr(android_sms_gateway, name), f"android_sms_gateway.{name} is missing"
+        assert getattr(domain, name) is getattr(webhooks, name)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -253,3 +253,103 @@ class TestHttpxAsyncHttpClientErrorHandling:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.response == {"error": "not found"}
+
+
+class TestEmptyBodyHandling:
+    """Test empty-body success handling (202 Accepted, no content)."""
+
+    def test_requests_returns_empty_dict_for_202_empty_body(self):
+        """Tests that RequestsHttpClient returns {} for a 202 empty body."""
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_response.content = b""
+
+        client = RequestsHttpClient()
+
+        assert client._process_response(mock_response) == {}
+
+    def test_httpx_returns_empty_dict_for_202_empty_body(self):
+        """Tests that HttpxHttpClient returns {} for a 202 empty body."""
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_response.content = b""
+
+        client = HttpxHttpClient()
+
+        assert client._process_response(mock_response) == {}
+
+    @pytest.mark.asyncio
+    async def test_httpx_async_returns_empty_dict_for_202_empty_body(self):
+        """Tests that HttpxAsyncHttpClient returns {} for a 202 empty body."""
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_response.content = b""
+
+        client = HttpxAsyncHttpClient()
+
+        assert await client._process_response(mock_response) == {}
+
+    @pytest.mark.asyncio
+    async def test_aiohttp_returns_empty_dict_for_202_empty_body(self):
+        """
+        Tests that AiohttpAsyncHttpClient returns {} for a 202 empty body
+        without Content-Type (json() raises ContentTypeError).
+        """
+        json = AsyncMock(
+            side_effect=aiohttp.ContentTypeError(
+                request_info=Mock(),
+                history=(),
+                message="Attempt to decode JSON with unexpected mimetype",
+            )
+        )
+
+        mock_response = Mock()
+        mock_response.status = 202
+        mock_response.json = json
+
+        client = AiohttpAsyncHttpClient()
+
+        assert await client._process_response(mock_response) == {}
+
+
+class TestInternalServerErrorHandling:
+    """Test 500 error status handling (refresh_inbox error path)."""
+
+    def test_requests_raises_internal_server_error_for_500(self):
+        """Tests that RequestsHttpClient maps 500 to InternalServerError."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.content = b'{"message": "boom"}'
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Server Error"
+        )
+        mock_response.json.return_value = {"message": "boom"}
+
+        client = RequestsHttpClient()
+
+        with pytest.raises(InternalServerError) as exc_info:
+            client._process_response(mock_response)
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.response == {"message": "boom"}
+
+    @pytest.mark.asyncio
+    async def test_aiohttp_raises_internal_server_error_for_500(self):
+        """Tests that AiohttpAsyncHttpClient maps 500 to InternalServerError."""
+        json = AsyncMock()
+        json.return_value = {"message": "boom"}
+
+        mock_response = Mock()
+        mock_response.status = 500
+        mock_response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=Mock(), history=(), status=500, message="500 Server Error"
+        )
+        mock_response.json = json
+
+        client = AiohttpAsyncHttpClient()
+
+        with pytest.raises(InternalServerError) as exc_info:
+            await client._process_response(mock_response)
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.response == {"message": "boom"}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,326 @@
+import datetime
+
+import pytest
+
+from android_sms_gateway.webhooks import (
+    SmsReceivedPayload,
+    SmsDataReceivedPayload,
+    SmsBatchReceivedPayload,
+    SmsBatchDataReceivedPayload,
+    MmsReceivedPayload,
+    MmsDownloadedPayload,
+    MmsBatchReceivedPayload,
+    MmsBatchDownloadedPayload,
+)
+
+# Webhook payload types: sms:received / sms:data-received
+
+
+def test_sms_received_payload_from_dict():
+    """
+    Tests that an SmsReceivedPayload can be instantiated from a dictionary
+    with all required and optional fields, and that received_at is parsed
+    into a datetime instance.
+    """
+    payload = {
+        "messageId": "msg_1",
+        "phoneNumber": "+15551234567",
+        "sender": "+15551234567",
+        "message": "Hello from the device",
+        "receivedAt": "2026-08-18T07:24:00Z",
+        "recipient": "+15559876543",
+        "simNumber": 2,
+    }
+
+    parsed = SmsReceivedPayload.from_dict(payload)
+
+    assert parsed.message_id == payload["messageId"]
+    assert parsed.phone_number == payload["phoneNumber"]
+    assert parsed.sender == payload["sender"]
+    assert parsed.message == payload["message"]
+    assert parsed.received_at == datetime.datetime.fromisoformat(
+        payload["receivedAt"].replace("Z", "+00:00")
+    )
+    assert isinstance(parsed.received_at, datetime.datetime)
+    assert parsed.recipient == payload["recipient"]
+    assert parsed.sim_number == payload["simNumber"]
+
+
+def test_sms_received_payload_from_dict_required_fields_only():
+    """
+    Tests that an SmsReceivedPayload can be instantiated with only the
+    required fields, leaving the optional ones as None.
+    """
+    payload = {
+        "messageId": "msg_2",
+        "phoneNumber": "+15551234567",
+        "sender": "+15551234567",
+        "message": "Minimal",
+        "receivedAt": "2026-08-18T08:30:00+02:00",
+    }
+
+    parsed = SmsReceivedPayload.from_dict(payload)
+
+    assert parsed.received_at == datetime.datetime.fromisoformat(payload["receivedAt"])
+    assert parsed.recipient is None
+    assert parsed.sim_number is None
+
+
+def test_sms_data_received_payload_from_dict():
+    """
+    Tests that an SmsDataReceivedPayload can be instantiated from a
+    dictionary with all required and optional fields, and that received_at
+    is parsed into a datetime instance.
+    """
+    payload = {
+        "messageId": "msg_3",
+        "phoneNumber": "+15551112222",
+        "sender": "+15551112222",
+        "data": "aGVsbG8gd29ybGQ=",
+        "receivedAt": "2026-08-18T09:00:00Z",
+        "recipient": "+15553334444",
+        "simNumber": 1,
+    }
+
+    parsed = SmsDataReceivedPayload.from_dict(payload)
+
+    assert parsed.message_id == payload["messageId"]
+    assert parsed.phone_number == payload["phoneNumber"]
+    assert parsed.sender == payload["sender"]
+    assert parsed.data == payload["data"]
+    assert parsed.received_at == datetime.datetime.fromisoformat(
+        payload["receivedAt"].replace("Z", "+00:00")
+    )
+    assert isinstance(parsed.received_at, datetime.datetime)
+    assert parsed.recipient == payload["recipient"]
+    assert parsed.sim_number == payload["simNumber"]
+
+
+# Batch webhook payload types
+
+
+def test_sms_batch_received_payload_from_dict():
+    """
+    Tests that an SmsBatchReceivedPayload parses its messages list into
+    SmsReceivedPayload instances.
+    """
+    payload = {
+        "messages": [
+            {
+                "messageId": "msg_1",
+                "phoneNumber": "+15551234567",
+                "sender": "+15551234567",
+                "message": "First",
+                "receivedAt": "2026-08-18T07:00:00Z",
+                "simNumber": 1,
+            },
+            {
+                "messageId": "msg_2",
+                "phoneNumber": "+15557654321",
+                "sender": "+15557654321",
+                "message": "Second",
+                "receivedAt": "2026-08-18T07:01:00Z",
+                "recipient": "+15559876543",
+            },
+        ]
+    }
+
+    parsed = SmsBatchReceivedPayload.from_dict(payload)
+
+    assert len(parsed.messages) == 2
+    assert isinstance(parsed.messages, tuple)
+    assert all(isinstance(message, SmsReceivedPayload) for message in parsed.messages)
+    assert parsed.messages[0].message_id == "msg_1"
+    assert parsed.messages[1].recipient == "+15559876543"
+    assert isinstance(parsed.messages[0].received_at, datetime.datetime)
+    assert parsed.messages[0].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][0]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[0].received_at.tzinfo is not None
+    assert parsed.messages[1].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][1]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[1].received_at.tzinfo is not None
+    with pytest.raises(TypeError):
+        parsed.messages[0] = None
+
+
+def test_sms_batch_data_received_payload_from_dict():
+    """
+    Tests that an SmsBatchDataReceivedPayload parses its messages list into
+    SmsDataReceivedPayload instances.
+    """
+    payload = {
+        "messages": [
+            {
+                "messageId": "msg_10",
+                "phoneNumber": "+15551112222",
+                "sender": "+15551112222",
+                "data": "ZGF0YTE=",
+                "receivedAt": "2026-08-18T09:00:00Z",
+            },
+            {
+                "messageId": "msg_11",
+                "phoneNumber": "+15553334444",
+                "sender": "+15553334444",
+                "data": "ZGF0YTI=",
+                "receivedAt": "2026-08-18T09:01:00Z",
+                "simNumber": 2,
+            },
+        ]
+    }
+
+    parsed = SmsBatchDataReceivedPayload.from_dict(payload)
+
+    assert len(parsed.messages) == 2
+    assert isinstance(parsed.messages, tuple)
+    assert all(
+        isinstance(message, SmsDataReceivedPayload) for message in parsed.messages
+    )
+    assert parsed.messages[0].data == "ZGF0YTE="
+    assert parsed.messages[1].sim_number == 2
+    assert parsed.messages[0].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][0]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[0].received_at.tzinfo is not None
+    assert parsed.messages[1].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][1]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[1].received_at.tzinfo is not None
+    with pytest.raises(TypeError):
+        parsed.messages[0] = None
+
+
+def test_mms_batch_received_payload_from_dict():
+    """
+    Tests that an MmsBatchReceivedPayload parses its messages list into
+    MmsReceivedPayload instances.
+    """
+    payload = {
+        "messages": [
+            {
+                "messageId": "mms_1",
+                "phoneNumber": "+15551234567",
+                "sender": "+15551234567",
+                "transactionId": "txn_1",
+                "contentClass": "personal",
+                "size": 2048,
+                "receivedAt": "2026-08-18T10:00:00Z",
+                "subject": "Photo",
+            },
+            {
+                "messageId": "mms_2",
+                "phoneNumber": "+15557654321",
+                "sender": "+15557654321",
+                "transactionId": "txn_2",
+                "contentClass": "advertisement",
+                "size": 512,
+                "receivedAt": "2026-08-18T10:05:00+03:00",
+                "recipient": "+15559876543",
+            },
+        ]
+    }
+
+    parsed = MmsBatchReceivedPayload.from_dict(payload)
+
+    assert len(parsed.messages) == 2
+    assert isinstance(parsed.messages, tuple)
+    assert all(isinstance(message, MmsReceivedPayload) for message in parsed.messages)
+    assert parsed.messages[0].subject == "Photo"
+    assert parsed.messages[1].recipient == "+15559876543"
+    assert isinstance(parsed.messages[0].received_at, datetime.datetime)
+    assert parsed.messages[0].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][0]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[0].received_at.tzinfo is not None
+    assert parsed.messages[1].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][1]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[1].received_at.tzinfo is not None
+    with pytest.raises(TypeError):
+        parsed.messages[0] = None
+
+
+def test_mms_batch_downloaded_payload_from_dict():
+    """
+    Tests that an MmsBatchDownloadedPayload parses its messages list into
+    MmsDownloadedPayload instances.
+    """
+    payload = {
+        "messages": [
+            {
+                "messageId": "mms_dl_1",
+                "phoneNumber": "+15551234567",
+                "sender": "+15551234567",
+                "attachments": [
+                    {
+                        "partId": 1,
+                        "contentType": "image/jpeg",
+                        "name": "photo.jpg",
+                        "size": 4096,
+                    },
+                    {
+                        "partId": 2,
+                        "contentType": "text/plain",
+                        "data": "aGVsbG8=",
+                    },
+                ],
+                "receivedAt": "2026-08-18T11:00:00Z",
+                "body": "Full MMS body",
+            },
+            {
+                "messageId": "mms_dl_2",
+                "phoneNumber": "+15557654321",
+                "sender": "+15557654321",
+                "attachments": [],
+                "receivedAt": "2026-08-18T11:05:00Z",
+                "simNumber": 1,
+            },
+        ]
+    }
+
+    parsed = MmsBatchDownloadedPayload.from_dict(payload)
+
+    assert len(parsed.messages) == 2
+    assert isinstance(parsed.messages, tuple)
+    assert all(isinstance(message, MmsDownloadedPayload) for message in parsed.messages)
+    assert parsed.messages[0].body == "Full MMS body"
+    assert len(parsed.messages[0].attachments) == 2
+    assert isinstance(parsed.messages[0].attachments, list)
+    assert parsed.messages[0].attachments[0].name == "photo.jpg"
+    assert parsed.messages[1].attachments == []
+    assert parsed.messages[1].sim_number == 1
+    assert parsed.messages[0].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][0]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[0].received_at.tzinfo is not None
+    assert parsed.messages[1].received_at == datetime.datetime.fromisoformat(
+        payload["messages"][1]["receivedAt"].replace("Z", "+00:00")
+    )
+    assert parsed.messages[1].received_at.tzinfo is not None
+    with pytest.raises(TypeError):
+        parsed.messages[0] = None
+
+
+@pytest.mark.parametrize(
+    "payload_cls",
+    [
+        SmsBatchReceivedPayload,
+        SmsBatchDataReceivedPayload,
+        MmsBatchReceivedPayload,
+        MmsBatchDownloadedPayload,
+    ],
+)
+@pytest.mark.parametrize(
+    "payload",
+    [{}, {"messages": None}, {"messages": "not-a-list"}, {"messages": {}}],
+)
+def test_batch_payload_from_dict_missing_or_non_list_messages(payload_cls, payload):
+    """
+    Tests that all four batch payloads tolerate a missing or non-list
+    'messages' key, resolving to an empty tuple (client-go nil-slice and
+    client-php isset/is_array guard parity).
+    """
+    parsed = payload_cls.from_dict(payload)
+
+    assert parsed.messages == ()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous inbox refresh with configurable time ranges, devices, message types, and webhook delivery.
  * Added disabled, individual, and batch webhook delivery modes.
  * Added typed payloads and events for individual and batched SMS and MMS messages.
  * Exposed inbox refresh requests and webhook types through the public API.

* **Documentation**
  * Updated guidance for inbox refresh, message queries, inbox listing, attachments, and webhook configuration.

* **Deprecations**
  * Marked inbox export methods as deprecated in favor of inbox refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->